### PR TITLE
Improved error-handling

### DIFF
--- a/pods/postgres.yaml
+++ b/pods/postgres.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regnskap-postgres
+  labels:
+    purpose: local-development
+spec:
+  restartPolicy: Never
+  containers:
+    - name: postgres
+      image: postgres:12.14
+      ports:
+        - containerPort: 5432
+          hostPort: 5432
+      env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: password

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>no.brreg.regnskap</groupId>
     <artifactId>regnskapsregister-api</artifactId>
     <name>Regnskapsregister</name>
-    <version>1.1.14</version>
+    <version>1.1.15</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -364,7 +364,6 @@
                             <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
                         </configuration>
                     </execution>
-                    
                 </executions>
             </plugin>
 

--- a/src/main/java/no/brreg/regnskap/controller/RegnskapApiImpl.java
+++ b/src/main/java/no/brreg/regnskap/controller/RegnskapApiImpl.java
@@ -61,9 +61,10 @@ public class RegnskapApiImpl implements no.brreg.regnskap.generated.api.Regnskap
             } else {
                 return new ResponseEntity<>(logList, HttpStatus.OK);
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getLog failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 
@@ -99,9 +100,10 @@ public class RegnskapApiImpl implements no.brreg.regnskap.generated.api.Regnskap
             ExternalUrls urls = new ExternalUrls(self, organizationCatalogue);
             String body = modelToString(createJenaResponse(regnskapList, urls), mimeTypeToJenaFormat(negotiatedMimeType));
             return ResponseEntity.ok().contentType(MediaType.asMediaType(negotiatedMimeType)).body(body);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getRegnskap failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 
@@ -138,9 +140,10 @@ public class RegnskapApiImpl implements no.brreg.regnskap.generated.api.Regnskap
             ExternalUrls urls = new ExternalUrls(self, organizationCatalogue);
             String body = modelToString(createJenaResponse(regnskap, urls), mimeTypeToJenaFormat(negotiatedMimeType));
             return ResponseEntity.ok().contentType(MediaType.asMediaType(negotiatedMimeType)).body(body);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getRegnskapById failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/no/brreg/regnskap/controller/StatistikkApiImpl.java
+++ b/src/main/java/no/brreg/regnskap/controller/StatistikkApiImpl.java
@@ -34,9 +34,10 @@ public class StatistikkApiImpl implements no.brreg.regnskap.generated.api.Statis
             } else {
                 return new ResponseEntity<>(logList, HttpStatus.OK);
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getStatisticsByIp failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 
@@ -50,9 +51,10 @@ public class StatistikkApiImpl implements no.brreg.regnskap.generated.api.Statis
             } else {
                 return new ResponseEntity<>(logList, HttpStatus.OK);
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getStatisticsByMethod failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 
@@ -66,9 +68,10 @@ public class StatistikkApiImpl implements no.brreg.regnskap.generated.api.Statis
             } else {
                 return new ResponseEntity<>(logList, HttpStatus.OK);
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            LOGGER.error("getStatisticsByOrgnr failed: ", e);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/no/brreg/regnskap/controller/TestApiImpl.java
+++ b/src/main/java/no/brreg/regnskap/controller/TestApiImpl.java
@@ -43,9 +43,10 @@ public class TestApiImpl implements no.brreg.regnskap.generated.api.TestApi {
                     throw e2;
                 }
             }
-        } catch (SQLException throwables) {
-            LOGGER.error("getConnection failed: " + throwables.getMessage());
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
 
         if (orgnr == null || orgnr.isEmpty()) {
@@ -54,5 +55,4 @@ public class TestApiImpl implements no.brreg.regnskap.generated.api.TestApi {
             return new ResponseEntity<>(orgnr, HttpStatus.OK);
         }
     }
-
 }

--- a/src/main/java/no/brreg/regnskap/controller/exception/InternalServerError.java
+++ b/src/main/java/no/brreg/regnskap/controller/exception/InternalServerError.java
@@ -1,0 +1,18 @@
+package no.brreg.regnskap.controller.exception;
+
+public class InternalServerError extends RuntimeException {
+    boolean logStackTrace = true;
+
+    public InternalServerError(String message, Throwable cause) {
+        this(message, cause, true);
+    }
+
+    public InternalServerError(String message, Throwable cause, boolean logStackTrace) {
+        super(message, cause);
+        this.logStackTrace = logStackTrace;
+    }
+
+    public InternalServerError(Throwable cause) {
+        super("Internal Server Error", cause);
+    }
+}

--- a/src/main/java/no/brreg/regnskap/controller/exception/RuntimeExceptionHandler.java
+++ b/src/main/java/no/brreg/regnskap/controller/exception/RuntimeExceptionHandler.java
@@ -1,0 +1,62 @@
+package no.brreg.regnskap.controller.exception;
+
+import no.brreg.regnskap.generated.model.ServerErrorRespons;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static java.time.ZoneOffset.UTC;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.ResponseEntity.status;
+import static java.time.Instant.now;
+
+@ControllerAdvice
+public class RuntimeExceptionHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeExceptionHandler.class);
+    private static final HttpStatus HTTP_STATUS = INTERNAL_SERVER_ERROR;
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseBody
+    public static ResponseEntity<Object> handleException(RuntimeException ex, HttpServletRequest webRequest) {
+        return handleException(new InternalServerError(ex), webRequest);
+    }
+
+    @ExceptionHandler(InternalServerError.class)
+    @ResponseBody
+    public static ResponseEntity<Object> handleException(InternalServerError ex, HttpServletRequest webRequest) {
+        String trace = generateUUID();
+        var errorResponseBody = new ServerErrorRespons()
+                .timestamp(getTimestamp())
+                .status(String.valueOf(INTERNAL_SERVER_ERROR.value()))
+                .error(INTERNAL_SERVER_ERROR.getReasonPhrase())
+                .message(ex.getMessage())
+                .path(webRequest.getRequestURI())
+                .trace(trace);
+
+        if (ex.logStackTrace) {
+            LOGGER.error(ex.getMessage() + ", Trace: {}", trace, ex);
+        } else {
+            LOGGER.error(ex.getMessage() + ", Trace: {}. Error: {}", trace, ex.getCause().getMessage());
+        }
+
+        return status(INTERNAL_SERVER_ERROR)
+                .body(errorResponseBody);
+    }
+
+    private static String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private static String getTimestamp() {
+        return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                .withZone(UTC)
+                .format(now());
+    }
+}

--- a/src/main/java/no/brreg/regnskap/repository/RegnskapRepository.java
+++ b/src/main/java/no/brreg/regnskap/repository/RegnskapRepository.java
@@ -397,7 +397,7 @@ public class RegnskapRepository {
             oppstillingsplan = Regnskap.OppstillingsplanEnum.fromValue(aarsregnskapstype.toLowerCase());
         } catch (IllegalArgumentException ex) {
             throw new InternalServerError(
-                    String.format("Regnskapet inneholder en oppstillingsplan som ikke er støttet (%s)", aarsregnskapstype),
+                    String.format("Regnskapet inneholder en oppstillingsplan som ikke er stottet (%s)", aarsregnskapstype),
                     ex,
                     false
             );

--- a/src/main/resources/specification/regnskapsregister.yaml
+++ b/src/main/resources/specification/regnskapsregister.yaml
@@ -71,6 +71,15 @@ paths:
             text/turtle:
               schema:
                 type: object
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
 
   /regnskapsregisteret/regnskap/{orgNummer}/{id}:
     get:
@@ -114,6 +123,15 @@ paths:
             text/turtle:
               schema:
                 type: object
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
 
   /regnskapsregisteret/regnskap/log:
     get:
@@ -136,6 +154,15 @@ paths:
                 type: array
                 items:
                   type: string
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
 
   /test/most-recent:
     get:
@@ -151,6 +178,15 @@ paths:
             text/plain:
               schema:
                 type: string
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
   /statistikk/by-ip:
     get:
       tags:
@@ -180,6 +216,15 @@ paths:
                 type: array
                 items:
                   type: string
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
   /statistikk/by-orgnr:
     get:
       tags:
@@ -209,6 +254,15 @@ paths:
                 type: array
                 items:
                   type: string
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
   /statistikk/by-method:
     get:
       tags:
@@ -238,46 +292,55 @@ paths:
                 type: array
                 items:
                   type: string
+        '500':
+          description: Feil oppstod
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerErrorRespons"
+              examples:
+                ServerErrorRespons:
+                  $ref: "#/components/examples/ServerErrorRespons"
 components:
   schemas:
     Regnskap:
-        type: object
-        description: Et regnskap for et gitt år
-        properties:
-          id:
-            type: integer
-            format: int32
-            description: system-generert id
-          journalnr:
-            type: string
-          regnskapstype:
-            $ref: "#/components/schemas/Regnskapstype"
-          regnskapDokumenttype:
-            type: String
-          virksomhet:
-            $ref: "#/components/schemas/Virksomhet"
-          regnskapsperiode:
-            $ref: "#/components/schemas/Tidsperiode"
-          valuta:
-            $ref: "#/components/schemas/Valutakode"
-          avviklingsregnskap:
-            type: boolean
-          oppstillingsplan:
-            type: string
-            enum:
+      type: object
+      description: Et regnskap for et gitt år
+      properties:
+        id:
+          type: integer
+          format: int32
+          description: system-generert id
+        journalnr:
+          type: string
+        regnskapstype:
+          $ref: "#/components/schemas/Regnskapstype"
+        regnskapDokumenttype:
+          type: String
+        virksomhet:
+          $ref: "#/components/schemas/Virksomhet"
+        regnskapsperiode:
+          $ref: "#/components/schemas/Tidsperiode"
+        valuta:
+          $ref: "#/components/schemas/Valutakode"
+        avviklingsregnskap:
+          type: boolean
+        oppstillingsplan:
+          type: string
+          enum:
             - smaa
             - store
             - oevrige
-          revisjon:
-            $ref: "#/components/schemas/Revisjon"
-          regnkapsprinsipper:
-            $ref: "#/components/schemas/Regnskapsprinsipper"
-          egenkapitalGjeld:
-            $ref: "#/components/schemas/EgenkapitalGjeld"
-          eiendeler:
-            $ref: "#/components/schemas/Eiendeler"
-          resultatregnskapResultat:
-            $ref: "#/components/schemas/ResultatregnskapResultat"
+        revisjon:
+          $ref: "#/components/schemas/Revisjon"
+        regnkapsprinsipper:
+          $ref: "#/components/schemas/Regnskapsprinsipper"
+        egenkapitalGjeld:
+          $ref: "#/components/schemas/EgenkapitalGjeld"
+        eiendeler:
+          $ref: "#/components/schemas/Eiendeler"
+        resultatregnskapResultat:
+          $ref: "#/components/schemas/ResultatregnskapResultat"
     ResultatregnskapResultat:
       type: object
       externalDocs:
@@ -304,11 +367,11 @@ components:
       type: object
       properties:
         sumEgenkapitalGjeld:
-            type: number
+          type: number
         egenkapital:
-            $ref: "#/components/schemas/Egenkapital"
+          $ref: "#/components/schemas/Egenkapital"
         gjeldOversikt:
-            $ref: "#/components/schemas/Gjeld"
+          $ref: "#/components/schemas/Gjeld"
     Eiendeler:
       type: object
       properties:
@@ -323,11 +386,11 @@ components:
         sumBankinnskuddOgKontanter:
           type: number
         sumEiendeler:
-            type: number
+          type: number
         omloepsmidler:
-            $ref: "#/components/schemas/Omloepsmidler"
+          $ref: "#/components/schemas/Omloepsmidler"
         anleggsmidler:
-            $ref: "#/components/schemas/Anleggsmidler"
+          $ref: "#/components/schemas/Anleggsmidler"
     Anleggsmidler:
       type: object
       properties:
@@ -466,3 +529,35 @@ components:
       enum:
         - SELSKAP
         - KONSERN
+    ServerErrorRespons:
+      type: object
+      description: Respons for generisk feilmelding
+      properties:
+        timestamp:
+          type: string
+          description: Tidspunkt feilen oppstod. Format er ISO-8601
+        status:
+          type: string
+          description: HTTP statuskode for feilmeldingen
+        error:
+          type: string
+          description: HTTP beskrivelse for status
+        message:
+          type: string
+          description: En tekstlig beskrivelse av feilen
+        path:
+          type: string
+          description: Sti til dette endepunktet
+        trace:
+          type: string
+          description: En tilfeldig generert UUID.
+  examples:
+    ServerErrorRespons:
+      summary: Error Respons
+      value:
+        timestamp: 2021-05-28T11:34:33.435+0000
+        status: 500
+        error: Internal Server Error
+        message: Internal Server Error
+        path: /regnskapsregisteret/regnskap/999999999
+        trace: 5631709a-6e3e-4b72-94e7-fcbf6341272a

--- a/src/test/java/no/brreg/regnskap/XmlTestDataInvalidOppstillingsplan.java
+++ b/src/test/java/no/brreg/regnskap/XmlTestDataInvalidOppstillingsplan.java
@@ -1,0 +1,391 @@
+package no.brreg.regnskap;
+
+public class XmlTestDataInvalidOppstillingsplan {
+
+    public static String xmlTestString = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+        "\n" +
+        "<deler>\n" +
+        "  <ant_poster>48</ant_poster>\n" +
+            "  <del>\n" +
+            "    <hode>\n" +
+            "      <orgnr>999888777</orgnr>\n" +
+            "      <regnskapstype>S</regnskapstype>\n" +
+            "      <regnaar>2023</regnaar>\n" +
+            "      <aarsregnskapstype>IKKESTOTTET</aarsregnskapstype>\n" +
+            "      <oppstillingsplan_versjonsnr>42</oppstillingsplan_versjonsnr>\n" +
+            "      <valutakode>NOK</valutakode>\n" +
+            "      <regnskap_dokumenttype>BAL</regnskap_dokumenttype>\n" +
+            "      <startdato>20180101</startdato>\n" +
+            "      <avslutningsdato>20181231</avslutningsdato>\n" +
+            "      <mottakstype>EMOT</mottakstype>\n" +
+            "      <avviklingsregnskap>N</avviklingsregnskap>\n" +
+            "      <feilvaloer>N</feilvaloer>\n" +
+            "      <journalnr>201942000</journalnr>\n" +
+            "      <mottatt_dato>20190325</mottatt_dato>\n" +
+            "      <orgform>AS</orgform>\n" +
+            "      <mor_i_konsern>N</mor_i_konsern>\n" +
+            "      <regler_smaa>J</regler_smaa>\n" +
+            "      <fleksible_poster>J</fleksible_poster>\n" +
+            "      <fravalg_revisjon>N</fravalg_revisjon>\n" +
+            "      <utarbeidet_regnskapsforer>J</utarbeidet_regnskapsforer>\n" +
+            "      <bistand_regnskapsforer>J</bistand_regnskapsforer>\n" +
+            "      <ifrs_selskap>N</ifrs_selskap>\n" +
+            "      <forenklet_ifrs_selskap>N</forenklet_ifrs_selskap>\n" +
+            "      <ifrs_konsern>N</ifrs_konsern>\n" +
+            "      <forenklet_ifrs_konsern>N</forenklet_ifrs_konsern>\n" +
+            "    </hode>\n" +
+            "    <info>\n" +
+            "      <feltkode>80</feltkode>\n" +
+            "      <sum>1113666.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1113666.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>85</feltkode>\n" +
+            "      <sum>1017299.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1017299.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>86</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>0.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>194</feltkode>\n" +
+            "      <sum>1123609.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123609.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>217</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>0.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>219</feltkode>\n" +
+            "      <sum>1123609.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123609.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>220</feltkode>\n" +
+            "      <sum>5484.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>5484.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>250</feltkode>\n" +
+            "      <sum>106310.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>106310.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>206</feltkode>\n" +
+            "      <sum>1123610.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123610.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>25012</feltkode>\n" +
+            "      <sum>1123611.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123611.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>6601</feltkode>\n" +
+            "      <sum>1123613.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123613.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>251</feltkode>\n" +
+            "      <sum>1123609.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1123609.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>282</feltkode>\n" +
+            "      <sum>3201.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>3201.00</tall>\n" +
+            "        <fritekst>Andre kortsiktige fordringer</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>326</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <notehenvisning>5,7</notehenvisning>\n" +
+            "        <fritekst>Varer</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>786</feltkode>\n" +
+            "      <sum>9943.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>9943.00</tall>\n" +
+            "        <fritekst>Bankinnskudd, kontanter o.l.</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>797</feltkode>\n" +
+            "      <sum>5048421.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>5048421.00</tall>\n" +
+            "        <fritekst>Varer</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>1119</feltkode>\n" +
+            "      <sum>1017299.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1017299.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>2255</feltkode>\n" +
+            "      <sum>1010000.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1010000.00</tall>\n" +
+            "        <notehenvisning>8</notehenvisning>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>2483</feltkode>\n" +
+            "      <sum>1815.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>1815.00</tall>\n" +
+            "        <notehenvisning>2</notehenvisning>\n" +
+            "        <fritekst>Betalbar skatt</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>3274</feltkode>\n" +
+            "      <sum>6310.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>6310.00</tall>\n" +
+            "        <notehenvisning>4</notehenvisning>\n" +
+            "        <fritekst>Annen egenkapital</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>3730</feltkode>\n" +
+            "      <sum>100000.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>100000.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>6946</feltkode>\n" +
+            "      <sum>2488202.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>2488202.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7108</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>0.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7126</feltkode>\n" +
+            "      <sum>7536624.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>7536624.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7127</feltkode>\n" +
+            "      <sum>7536624.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>7536624.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7128</feltkode>\n" +
+            "      <sum>1110465.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1110465.00</tall>\n" +
+            "        <notehenvisning>6</notehenvisning>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7140</feltkode>\n" +
+            "      <sum>235.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>235.00</tall>\n" +
+            "        <fritekst>Annen egenkapital</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7142</feltkode>\n" +
+            "      <sum>100235.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>100235.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7150</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <notehenvisning>5</notehenvisning>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7151</feltkode>\n" +
+            "      <sum>5256898.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>5256898.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7156</feltkode>\n" +
+            "      <sum>5256898.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>5256898.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7162</feltkode>\n" +
+            "      <sum>360000.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>360000.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7175</feltkode>\n" +
+            "      <sum>1373000.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>1373000.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7183</feltkode>\n" +
+            "      <sum>2179490.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>2179490.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7184</feltkode>\n" +
+            "      <sum>7436388.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>7436388.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>7185</feltkode>\n" +
+            "      <sum>7536624.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>7536624.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>8015</feltkode>\n" +
+            "      <sum>2488202.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>2488202.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>9702</feltkode>\n" +
+            "      <sum>6310.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>6310.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>9984</feltkode>\n" +
+            "      <sum>100000.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>100000.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>9985</feltkode>\n" +
+            "      <sum>235.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>235.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>10293</feltkode>\n" +
+            "      <sum>743.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>743.00</tall>\n" +
+            "        <fritekst>Betalbar skatt</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>10926</feltkode>\n" +
+            "      <sum>0.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <fritekst>Gjeld til kredittinstitusjoner</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>13203</feltkode>\n" +
+            "      <sum>445747.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>445747.00</tall>\n" +
+            "        <fritekst>Gjeld til kredittinstitusjoner</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>20488</feltkode>\n" +
+            "      <sum>100000.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>100000.00</tall>\n" +
+            "        <notehenvisning>3,4</notehenvisning>\n" +
+            "        <fritekst>Selskapskapital</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>20489</feltkode>\n" +
+            "      <sum>100000.00</sum>\n" +
+            "      <post posttype=\"fleksibel\" nr=\"1\">\n" +
+            "        <tall>100000.00</tall>\n" +
+            "        <fritekst>Selskapskapital</fritekst>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>25013</feltkode>\n" +
+            "      <sum>5048421.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>5048421.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>25020</feltkode>\n" +
+            "      <sum>5256898.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>5256898.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "    <info>\n" +
+            "      <feltkode>29042</feltkode>\n" +
+            "      <sum>9943.00</sum>\n" +
+            "      <post posttype=\"standard\" nr=\"1\">\n" +
+            "        <tall>9943.00</tall>\n" +
+            "      </post>\n" +
+            "    </info>\n" +
+            "  </del>\n" +
+        "</deler>";
+}


### PR DESCRIPTION
* Add global exception handler
* Unnsupported "oppstillingsplan" no longer logs stack-trace, instead logs a sensible error-message
* 500 Internal server error-responsens now contains a JSON-body with information about the error.
* Updated openapi-spec to reflect changes to 500-responses