### PR TITLE
fix: time-scew of updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-CHECK_BRANCH := main
-CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 CURRENT_REVISION := $(shell git rev-parse HEAD)
 
 run-psql-dev:
@@ -7,17 +5,11 @@ run-psql-dev:
 reset-sql-dev:
 	podman container rm --force postgres_regnskap
 
-ifeq ($(CURRENT_BRANCH),$(CHECK_BRANCH))
 trigger-pipeline:
 	oc login -u "${USER}" --server "https://api.ocp01.ut.base.brreg.no:6443"
 	oc project regnskap-registerinfo
-	tkn pipeline start "regnskap-opendata-api" --showlog --param "revision=$(CURRENT_REVISION)" --use-param-defaults
+	tkn pipeline start "regnskap-opendata-api" --showlog --param "revision=$(CURRENT_REVISION)" --param "force_image_build=true" --use-param-defaults
 	@echo "${CURRENT_REVISION}" built successfully. Use this hash to deploy the new image from the appconfig.
 	@echo "Remember to update the hash for both deployments:"
 	@echo "- regnskap-opendata-api"
 	@echo "- regnskap-opendata-updater"
-endif
-ifneq ($(CURRENT_BRANCH),$(CHECK_BRANCH))
-trigger-pipeline:
-	@echo "Need to be on main branch to trigger pipeline"
-endif


### PR DESCRIPTION
- There is no need to wait 24+1 hours before the next update. This causes update scheduler to be scewed 1 hour every day. It may also lead to missed updates for up to 25 hours if the app is rebooted right before a new file is available.  We can afford to check for updates every hour every day to avoid these complications.